### PR TITLE
[stp] implement fetcher utilities and update downloads

### DIFF
--- a/src/stp/fetchers/__init__.py
+++ b/src/stp/fetchers/__init__.py
@@ -1,0 +1,18 @@
+"""Spatial data fetcher helpers."""
+
+from .csv import fetch_csv_direct
+from .geojson import fetch_geojson_direct
+from .arcgis import fetch_arcgis_vector, fetch_arcgis_table
+from .gdb import fetch_gdb_or_zip
+from .gpkg import fetch_gpkg_layers
+from .socrata import dispatch_socrata_table
+
+__all__ = [
+    "fetch_csv_direct",
+    "fetch_geojson_direct",
+    "fetch_arcgis_vector",
+    "fetch_arcgis_table",
+    "fetch_gdb_or_zip",
+    "fetch_gpkg_layers",
+    "dispatch_socrata_table",
+]

--- a/src/stp/fetchers/arcgis.py
+++ b/src/stp/fetchers/arcgis.py
@@ -1,0 +1,52 @@
+"""Fetchers for ArcGIS REST services."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import List, Tuple
+
+import geopandas as gpd
+
+from .. import http_client
+from ..storage.file_storage import sanitize_layer_name
+from ..settings import DEFAULT_EPSG
+
+__all__ = ["fetch_arcgis_vector", "fetch_arcgis_table"]
+
+
+def _build_query_url(service_url: str, as_geojson: bool = True) -> str:
+    """Return an ArcGIS REST query URL for *service_url*."""
+    base = service_url.rstrip("/")
+    if not base.lower().endswith("query"):
+        base = f"{base}/query"
+    params = "where=1%%3D1&outFields=*&returnGeometry=true"
+    if as_geojson:
+        params += "&outSR=4326&f=geojson"
+    else:
+        params += "&f=json"
+    return f"{base}?{params}"
+
+
+def fetch_arcgis_vector(
+    service_url: str,
+) -> List[Tuple[str, gpd.GeoDataFrame, int, int]]:
+    """Fetch vector data from an ArcGIS FeatureServer layer."""
+    url = _build_query_url(service_url, as_geojson=True)
+    data = http_client.fetch_bytes(url)
+    gdf = gpd.read_file(BytesIO(data))
+    epsg = gdf.crs.to_epsg() or DEFAULT_EPSG
+    layer_name = sanitize_layer_name(Path(service_url).stem)
+    return [(layer_name, gdf, epsg, 4326)]
+
+
+def fetch_arcgis_table(
+    service_url: str,
+) -> List[Tuple[str, gpd.GeoDataFrame, int]]:
+    """Fetch a non-spatial table from an ArcGIS service."""
+    url = _build_query_url(service_url, as_geojson=True)
+    data = http_client.fetch_bytes(url)
+    gdf = gpd.read_file(BytesIO(data))
+    gdf.set_crs(epsg=DEFAULT_EPSG, inplace=True)
+    layer_name = sanitize_layer_name(Path(service_url).stem)
+    return [(layer_name, gdf, DEFAULT_EPSG)]

--- a/src/stp/fetchers/gdb.py
+++ b/src/stp/fetchers/gdb.py
@@ -1,0 +1,39 @@
+"""Fetchers for zipped shapefiles or geodatabases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+from tempfile import TemporaryDirectory
+import zipfile
+
+import fiona
+import geopandas as gpd
+
+from .. import http_client
+from ..storage.file_storage import sanitize_layer_name
+from ..settings import DEFAULT_EPSG
+
+__all__ = ["fetch_gdb_or_zip"]
+
+
+def fetch_gdb_or_zip(url: str) -> List[Tuple[str, gpd.GeoDataFrame, int]]:
+    """Download a zipped archive and extract layers."""
+    data = http_client.fetch_bytes(url)
+    results: List[Tuple[str, gpd.GeoDataFrame, int]] = []
+    with TemporaryDirectory() as tmpdir:
+        zip_path = Path(tmpdir) / "data.zip"
+        with open(zip_path, "wb") as fh:
+            fh.write(data)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmpdir)
+        for shp in Path(tmpdir).rglob("*.shp"):
+            gdf = gpd.read_file(shp)
+            epsg = gdf.crs.to_epsg() or DEFAULT_EPSG
+            results.append((sanitize_layer_name(shp.stem), gdf, epsg))
+        for gdb in Path(tmpdir).rglob("*.gdb"):
+            for layer in fiona.listlayers(str(gdb)):
+                gdf = gpd.read_file(gdb, layer=layer)
+                epsg = gdf.crs.to_epsg() or DEFAULT_EPSG
+                results.append((sanitize_layer_name(layer), gdf, epsg))
+    return results

--- a/src/stp/fetchers/gpkg.py
+++ b/src/stp/fetchers/gpkg.py
@@ -1,0 +1,38 @@
+"""Fetch layers from a GeoPackage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+from tempfile import TemporaryDirectory
+
+import fiona
+import geopandas as gpd
+
+from .. import http_client
+from ..storage.file_storage import sanitize_layer_name
+from ..settings import DEFAULT_EPSG
+
+__all__ = ["fetch_gpkg_layers"]
+
+
+def fetch_gpkg_layers(
+    path_or_url: str,
+) -> List[Tuple[str, gpd.GeoDataFrame, int]]:
+    """Load all layers from a GeoPackage file or URL."""
+    tmpdir: TemporaryDirectory | None = None
+    gpkg_path = Path(path_or_url)
+    if path_or_url.startswith("http"):
+        tmpdir = TemporaryDirectory()
+        gpkg_path = Path(tmpdir.name) / "data.gpkg"
+        gpkg_path.write_bytes(http_client.fetch_bytes(path_or_url))
+    try:
+        results: List[Tuple[str, gpd.GeoDataFrame, int]] = []
+        for layer in fiona.listlayers(str(gpkg_path)):
+            gdf = gpd.read_file(gpkg_path, layer=layer)
+            epsg = gdf.crs.to_epsg() or DEFAULT_EPSG
+            results.append((sanitize_layer_name(layer), gdf, epsg))
+        return results
+    finally:
+        if tmpdir is not None:
+            tmpdir.cleanup()

--- a/src/stp/fetchers/socrata.py
+++ b/src/stp/fetchers/socrata.py
@@ -1,0 +1,15 @@
+"""Placeholder Socrata fetcher."""
+
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+
+import geopandas as gpd
+
+__all__ = ["dispatch_socrata_table"]
+
+
+def dispatch_socrata_table(url: str, app_token: Optional[str] = None
+                           ) -> List[Tuple[str, gpd.GeoDataFrame, int]]:
+    """Temporary stub for Socrata dataset fetching."""
+    raise NotImplementedError("Socrata fetcher not implemented")

--- a/src/stp/scripts/download_utils.py
+++ b/src/stp/scripts/download_utils.py
@@ -1,0 +1,28 @@
+"""Helper constants for download scripts."""
+
+from __future__ import annotations
+
+from ..fetchers import (
+    fetch_arcgis_table,
+    fetch_arcgis_vector,
+    fetch_csv_direct,
+    fetch_gdb_or_zip,
+    fetch_geojson_direct,
+    fetch_gpkg_layers,
+    dispatch_socrata_table,
+)
+
+FETCHERS = {
+    ("socrata", "csv"): dispatch_socrata_table,
+    ("socrata", "json"): dispatch_socrata_table,
+    ("socrata", "geojson"): dispatch_socrata_table,
+    ("socrata", "shapefile"): dispatch_socrata_table,
+    ("arcgis", "csv"): fetch_arcgis_table,
+    ("arcgis", "json"): fetch_arcgis_table,
+    ("arcgis", "geojson"): fetch_arcgis_vector,
+    ("arcgis", "shapefile"): fetch_arcgis_vector,
+    (None, "csv"): fetch_csv_direct,
+    (None, "geojson"): fetch_geojson_direct,
+    (None, "shapefile"): fetch_gdb_or_zip,
+    (None, "gpkg"): fetch_gpkg_layers,
+}

--- a/src/stp/storage/file_storage.py
+++ b/src/stp/storage/file_storage.py
@@ -5,6 +5,13 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 
+__all__ = [
+    "get_geopackage_path",
+    "sanitize_layer_name",
+    "export_spatial_layer",
+    "reproject_all_layers",
+]
+
 LAYER_NAME_MAX_LENGTH = 60
 
 
@@ -27,6 +34,12 @@ def sanitize_layer_name(name: str) -> str:
     if safe and safe[0].isdigit():
         safe = "_" + safe
     return safe[:LAYER_NAME_MAX_LENGTH]
+
+
+def export_spatial_layer(gdf: gpd.GeoDataFrame, layer_name: str,
+                         gpkg_path: Path) -> None:
+    """Write ``gdf`` to ``gpkg_path`` under ``layer_name``."""
+    gdf.to_file(gpkg_path, layer=layer_name, driver="GPKG")
 
 
 def reproject_all_layers(


### PR DESCRIPTION
## Summary
- update download script imports to use `stp` modules
- add missing fetcher utilities for ArcGIS, zipped archives and GeoPackages
- provide dispatch map in `stp.scripts.download_utils`
- add `export_spatial_layer` helper
- fix data source path

## Testing
- `flake8 bin/download_data.py src/stp/fetchers/arcgis.py src/stp/fetchers/gdb.py src/stp/fetchers/gpkg.py src/stp/fetchers/socrata.py src/stp/fetchers/__init__.py src/stp/storage/file_storage.py src/stp/scripts/download_utils.py --max-line-length=79`
- `pytest tests/ --ignore=tests/gis_* --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e6df3d748326a8deb10c0f02a9d1