### PR TITLE
Remove unused settings module

### DIFF
--- a/src/stp/fetchers/arcgis.py
+++ b/src/stp/fetchers/arcgis.py
@@ -10,7 +10,9 @@ import geopandas as gpd
 
 from .. import http_client
 from ..storage.file_storage import sanitize_layer_name
-from ..settings import DEFAULT_EPSG
+from ..config_loader import get_constant
+
+DEFAULT_EPSG: int = int(get_constant("default_epsg"))
 
 __all__ = ["fetch_arcgis_vector", "fetch_arcgis_table"]
 

--- a/src/stp/fetchers/csv.py
+++ b/src/stp/fetchers/csv.py
@@ -12,7 +12,9 @@ from shapely.geometry import Point
 
 from .. import http_client
 from ..storage.file_storage import sanitize_layer_name
-from ..settings import DEFAULT_EPSG
+from ..config_loader import get_constant
+
+DEFAULT_EPSG: int = int(get_constant("default_epsg"))
 
 logger = logging.getLogger(__name__)
 

--- a/src/stp/fetchers/gdb.py
+++ b/src/stp/fetchers/gdb.py
@@ -12,7 +12,9 @@ import geopandas as gpd
 
 from .. import http_client
 from ..storage.file_storage import sanitize_layer_name
-from ..settings import DEFAULT_EPSG
+from ..config_loader import get_constant
+
+DEFAULT_EPSG: int = int(get_constant("default_epsg"))
 
 __all__ = ["fetch_gdb_or_zip"]
 

--- a/src/stp/fetchers/geojson.py
+++ b/src/stp/fetchers/geojson.py
@@ -10,7 +10,9 @@ from fiona.errors import DriverError, FionaValueError
 
 from .. import http_client
 from ..storage.file_storage import sanitize_layer_name
-from ..settings import DEFAULT_EPSG
+from ..config_loader import get_constant
+
+DEFAULT_EPSG: int = int(get_constant("default_epsg"))
 
 logger = logging.getLogger(__name__)
 

--- a/src/stp/fetchers/gpkg.py
+++ b/src/stp/fetchers/gpkg.py
@@ -11,7 +11,9 @@ import geopandas as gpd
 
 from .. import http_client
 from ..storage.file_storage import sanitize_layer_name
-from ..settings import DEFAULT_EPSG
+from ..config_loader import get_constant
+
+DEFAULT_EPSG: int = int(get_constant("default_epsg"))
 
 __all__ = ["fetch_gpkg_layers"]
 

--- a/src/stp/settings.py
+++ b/src/stp/settings.py
@@ -1,6 +1,0 @@
-"""Global constants for the STP package."""
-
-DEFAULT_EPSG = 4326
-NYSP_EPSG = 2263
-# TODO Delete this, remove any scripts referencing this and utilize the config 
-# defaults.yaml / user.example.yaml

--- a/src/stp/stp.md
+++ b/src/stp/stp.md
@@ -51,7 +51,6 @@ stp/
 ├── download.py
 ├── fields\_inventory.py
 ├── http\_client.py
-├── settings.py
 ├── table.py
 └── **init**.py
 
@@ -64,7 +63,6 @@ stp/
 | Module | Purpose |
 |--------|---------|
 | **config_loader.py** | Read YAML/ENV configuration & expose `get_setting`, `get_constant`. |
-| **settings.py** | Hard-coded fall-backs (NYSP EPSG 2263, default filenames, etc.). |
 | **download.py** | “Orchestrator” – loops through every fetcher listed in config and drops raw files into `Data/raw/`. |
 | **http_client.py** | Thin `requests.Session` wrapper with retry & back-off. |
 | **data_cleaning.py** | Pipeline runner – re-projects, trims fields, fixes datatypes using functions from `cleaning/`. |


### PR DESCRIPTION
## Summary
- delete `settings.py`
- get `DEFAULT_EPSG` via `config_loader.get_constant`
- document updated folder contents

## Testing
- `flake8 src/stp/ --max-line-length=79` *(fails: command not found)*
- `pylint src/stp/` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for geopandas, yaml, requests, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_686b814881e883268e07aeb8a735b70e